### PR TITLE
Add support for VMWare VMX Builder.

### DIFF
--- a/lib/packer/builder.rb
+++ b/lib/packer/builder.rb
@@ -7,6 +7,7 @@ module Packer
     AMAZON_INSTANCE = 'amazon-instance'
     DOCKER          = 'docker'
     VIRTUALBOX_ISO  = 'virtualbox-iso'
+    VMWARE_VMX      = 'vmware-vmx'
     NULL            = 'null'
 
     VALID_BUILDER_TYPES = [
@@ -14,6 +15,7 @@ module Packer
       AMAZON_INSTANCE,
       DOCKER,
       VIRTUALBOX_ISO,
+      VMWARE_VMX,
       NULL
     ]
 
@@ -29,6 +31,7 @@ module Packer
         AMAZON_INSTANCE => Packer::Builder::Amazon::Instance,
         DOCKER          => Packer::Builder::Docker,
         VIRTUALBOX_ISO  => Packer::Builder::VirtualBoxISO,
+        VMWARE_VMX      => Packer::Builder::VMWareVMX,
         NULL            => Packer::Builder::Null
       }.fetch(type).new
     end

--- a/lib/packer/builders/all.rb
+++ b/lib/packer/builders/all.rb
@@ -2,4 +2,5 @@
 require 'packer/builders/amazon'
 require 'packer/builders/docker'
 require 'packer/builders/virtualbox'
+require 'packer/builders/vmware_vmx'
 require 'packer/builders/null'

--- a/lib/packer/builders/vmware_vmx.rb
+++ b/lib/packer/builders/vmware_vmx.rb
@@ -1,0 +1,110 @@
+module Packer
+  class Builder
+    class VMWareVMX < Builder
+      def initialize
+        super
+        data['type'] = VMWARE_VMX
+        add_required(
+          'source_path',
+          'ssh_username'
+        )
+      end
+
+      def source_path(path)
+        __add_string('source_path', path)
+      end
+
+      def ssh_username(username)
+        __add_string('ssh_username', username)
+      end
+
+      def ssh_password(password)
+        __add_string('ssh_password', password)
+      end
+
+      def boot_command(commands)
+        __add_array_of_strings('boot_command', commands)
+      end
+
+      def boot_wait(wait)
+        __add_string('boot_wait', wait)
+      end
+
+      def floppy_files(files)
+        __add_array_of_strings('floppy_files', files)
+      end
+
+      def fusion_app_path(app_path)
+        __add_string('fusion_app_path', app_path)
+      end
+
+      def headless(bool)
+        __add_boolean('headless', bool)
+      end
+
+      def http_directory(path)
+        __add_string('http_directory', path)
+      end
+
+      def http_port_min(port)
+        __add_integer('http_port_min', port)
+      end
+
+      def http_port_max(port)
+        __add_integer('http_port_max', port)
+      end
+
+      def output_directory(path)
+        __add_string('output_directory', path)
+      end
+
+      def shutdown_command(command)
+        __add_string('shutdown_command', command)
+      end
+
+      def shutdown_timeout(timeout)
+        __add_string('shutdown_timeout', timeout)
+      end
+
+      def skip_compaction(bool)
+        __add_boolean('skip_compaction', bool)
+      end
+
+      def ssh_key_path(path)
+        __add_string('ssh_key_path', path)
+      end
+
+      def ssh_port(port)
+        __add_integer('ssh_port', port)
+      end
+
+      def ssh_skip_request_pty(bool)
+        __add_boolean('ssh_skip_request_pty', bool)
+      end
+
+      def ssh_wait_timeout(timeout)
+        __add_string('ssh_wait_timeout', timeout)
+      end
+
+      def vm_name(name)
+        __add_string('vm_name', name)
+      end
+
+      def vmx_data(data_hash)
+        __add_hash('vmx_data', data_hash)
+      end
+
+      def vmx_data_post(data_hash)
+        __add_hash('vmx_data_post', data_hash)
+      end
+
+      def vnc_port_min(port)
+        __add_integer('vnc_port_min', port)
+      end
+
+      def vnc_port_max(port)
+        __add_integer('vnc_port_max', port)
+      end
+    end
+  end
+end

--- a/spec/packer/builders/vmware_vmx_spec.rb
+++ b/spec/packer/builders/vmware_vmx_spec.rb
@@ -1,0 +1,29 @@
+# Encoding: utf-8
+require 'spec_helper'
+
+RSpec.describe Packer::Builder::VMWareVMX do
+  let(:builder) { Packer::Builder.get_builder(Packer::Builder::VMWARE_VMX) }
+
+  describe '#initialize' do
+    it 'has a type of VMWare VMX' do
+      expect(builder.data['type']).to eq(Packer::Builder::VMWARE_VMX)
+    end
+
+    it 'requires source_path' do
+      expect { builder.validate }.to raise_error(Packer::DataObject::DataValidationError)
+      builder.source_path 'path'
+      builder.ssh_username 'user'
+      expect { builder.validate }.not_to raise_error
+    end
+  end
+
+  describe '#vmx_data' do
+    it 'adds a hash of arbitrary data' do
+      builder.vmx_data(
+        key1: 'value1',
+        key2: 'value2'
+      )
+      expect(builder.data['vmx_data'].keys.length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
This time against the correct branch.

```
require 'packer-config'

class BuildarCLI < Thor
  desc 'build', 'Build it all'
  def build
    config = Packer::Config.new 'coreos-vmware.json'
    config.description 'builds a coreos image'


    builder = config.add_builder Packer::Builder::VMWARE_VMX
    builder.source_path File.join(ENV['HOME'], 'dev/coreos/coreos_production_vmware_insecure/coreos_production_vmware_insecure.vmx')
    builder.ssh_username 'core'
    builder.ssh_key_path File.join(ENV['HOME'], 'dev/coreos/coreos_production_vmware_insecure/insecure_ssh_key')
    builder.shutdown_command 'sudo shutdown -P now'
    builder.headless true

    config.validate
    config.build
  end
end
```

```
(grepory@gregs-mbp)(10:34:23)(~/dev/gi/buildar)
λ be buildar build
vmware-vmx output will be in this color.

==> vmware-vmx: Cloning source VM...
==> vmware-vmx: Starting virtual machine...
    vmware-vmx: The VM will be run headless, without a GUI. If you want to
    vmware-vmx: view the screen of the VM, connect via VNC without a password to
    vmware-vmx: 127.0.0.1:5981
==> vmware-vmx: Waiting 10s for boot...
==> vmware-vmx: Connecting to VM via VNC
==> vmware-vmx: Typing the boot command over VNC...
==> vmware-vmx: Waiting for SSH to become available...
==> vmware-vmx: Connected to SSH!
==> vmware-vmx: Gracefully halting virtual machine...
    vmware-vmx: Waiting for VMware to clean up after itself...
==> vmware-vmx: Deleting unnecessary VMware files...
    vmware-vmx: Deleting: output-vmware-vmx/packer-vmware-vmx-1427823279.plist
    vmware-vmx: Deleting: output-vmware-vmx/vmware.log
==> vmware-vmx: Cleaning VMX prior to finishing up...
    vmware-vmx: Unmounting floppy from VMX...
==> vmware-vmx: Compacting the disk image
Build 'vmware-vmx' finished.

==> Builds finished. The artifacts of successful builds are:
--> vmware-vmx: VM files in directory: output-vmware-vmx
```