### PR TITLE
Add communicator and Winrm options

### DIFF
--- a/lib/packer/builders/amazon.rb
+++ b/lib/packer/builders/amazon.rb
@@ -12,7 +12,7 @@ module Packer
           'instance_type',
           'region',
           'source_ami',
-          'ssh_username'
+          ['ssh_username', 'communicator']
         )
       end
 
@@ -138,6 +138,30 @@ module Packer
 
       def vpc_id(id)
         self.__add_string('vpc_id', id)
+      end
+
+      def communicator(comm)
+        self.__add_string('communicator', comm)
+      end
+
+      def winrm_host(host)
+        self.__add_string('winrm_host', host)
+      end
+
+      def winrm_port(port)
+        self.__add_string('winrm_port', port)
+      end
+
+      def winrm_username(username)
+        self.__add_string('winrm_username', username)
+      end
+
+      def winrm_password(password)
+        self.__add_string('winrm_password', password)
+      end
+
+      def winrm_timeout(timeout)
+        self.__add_string('winrm_timeout', timeout)
       end
 
       class EBS < Amazon

--- a/lib/packer/builders/virtualbox.rb
+++ b/lib/packer/builders/virtualbox.rb
@@ -12,7 +12,7 @@ module Packer
           'iso_checksum',
           'iso_checksum_type',
           'iso_url',
-          'ssh_username'
+          ['ssh_username', 'communicator']
         )
       end
 
@@ -150,6 +150,30 @@ module Packer
 
       def vm_name(name)
         self.__add_string('vm_name', name)
+      end
+
+      def communicator(comm)
+        self.__add_string('communicator', comm)
+      end
+
+      def winrm_host(host)
+        self.__add_string('winrm_host', host)
+      end
+
+      def winrm_port(port)
+        self.__add_string('winrm_port', port)
+      end
+
+      def winrm_username(username)
+        self.__add_string('winrm_username', username)
+      end
+
+      def winrm_password(password)
+        self.__add_string('winrm_password', password)
+      end
+
+      def winrm_timeout(timeout)
+        self.__add_string('winrm_timeout', timeout)
       end
     end
   end

--- a/lib/packer/builders/vmware_iso.rb
+++ b/lib/packer/builders/vmware_iso.rb
@@ -12,7 +12,7 @@ module Packer
           'iso_checksum',
           'iso_checksum_type',
           'iso_url',
-          'ssh_username'
+          ['ssh_username', 'communicator']
         )
       end
 
@@ -200,6 +200,30 @@ module Packer
 
       def vnc_port_max(port)
         self.__add_integer('vnc_port_max', port)
+      end
+
+      def communicator(comm)
+        self.__add_string('communicator', comm)
+      end
+
+      def winrm_host(host)
+        self.__add_string('winrm_host', host)
+      end
+
+      def winrm_port(port)
+        self.__add_string('winrm_port', port)
+      end
+
+      def winrm_username(username)
+        self.__add_string('winrm_username', username)
+      end
+
+      def winrm_password(password)
+        self.__add_string('winrm_password', password)
+      end
+
+      def winrm_timeout(timeout)
+        self.__add_string('winrm_timeout', timeout)
       end
     end
   end

--- a/lib/packer/builders/vmware_vmx.rb
+++ b/lib/packer/builders/vmware_vmx.rb
@@ -6,7 +6,7 @@ module Packer
         data['type'] = VMWARE_VMX
         add_required(
           'source_path',
-          'ssh_username'
+          ['ssh_username', 'communicator']
         )
       end
 
@@ -104,6 +104,30 @@ module Packer
 
       def vnc_port_max(port)
         __add_integer('vnc_port_max', port)
+      end
+
+      def communicator(comm)
+        self.__add_string('communicator', comm)
+      end
+
+      def winrm_host(host)
+        self.__add_string('winrm_host', host)
+      end
+
+      def winrm_port(port)
+        self.__add_string('winrm_port', port)
+      end
+
+      def winrm_username(username)
+        self.__add_string('winrm_username', username)
+      end
+
+      def winrm_password(password)
+        self.__add_string('winrm_password', password)
+      end
+
+      def winrm_timeout(timeout)
+        self.__add_string('winrm_timeout', timeout)
       end
     end
   end


### PR DESCRIPTION
Added the communicator and winrm options to builders that were using ssh_usernames. Packer added a communicator option to builders in 0.8 that allowed people to use winrm instead of ssh for windows machines that might be listening for winrm.

I didn't add the ssh specific stuff because this was all a little new to me and the only builder I'm even slightly familiar with is the amazon one. This was the change I needed to get my project working. Maybe I could add the communicator stuff into the base builder class? Let me know what I can do. Thanks!

https://www.hashicorp.com/blog/packer-0-8.html