### PR TITLE
Expand Runner::run! method to gracefully accept -debug packer option

### DIFF
--- a/lib/packer/runner.rb
+++ b/lib/packer/runner.rb
@@ -8,10 +8,13 @@ module Packer
 
     def self.run!(*args, quiet: false)
       cmd = Shellwords.shelljoin(args.flatten)
+
+      debug = cmd.include? '-debug'
+
       status = 0
       stdout = ''
       stderr = ''
-      if quiet
+      if quiet && !debug
         # Run without streaming std* to any screen
         stdout, stderr, status = Open3.capture3(cmd)
       else
@@ -29,6 +32,10 @@ module Packer
             until (raw_line = std_err.gets).nil? do
               stderr << raw_line
             end
+          end
+
+          Thread.new do
+            std_in.puts $stdin.gets while thread.alive?
           end
 
           thread.join # don't exit until the external process is done


### PR DESCRIPTION
Devs in my organization wanted their packer-config built ami's to be debuggable, so I set up the code in run! to check for the "-debug" packer_option being passed in and allow interaction with the subprocess' stdin, as well as forced it to print to parent process stdout/stderr. Seemed like the most graceful solution to me.
