### PR TITLE
Add windows provisioners with functionality for key dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ spec/integration/centos-6.*-x86_64-virtualbox
 /test/version_tmp/
 /tmp/
 /.idea/
+tags
 
 ## Specific to RubyMotion:
 .dat*

--- a/lib/packer/provisioner.rb
+++ b/lib/packer/provisioner.rb
@@ -5,6 +5,8 @@ require 'packer/dataobject'
 module Packer
   class Provisioner < Packer::DataObject
     SHELL             = 'shell'
+    WINDOWS_SHELL     = 'windows-shell'
+    POWERSHELL        = 'powershell'
     FILE              = 'file'
     SALT              = 'salt-masterless'
     ANSIBLE           = 'ansible-local'
@@ -15,6 +17,8 @@ module Packer
 
     VALID_PROVISIONER_TYPES = [
       SHELL,
+      WINDOWS_SHELL,
+      POWERSHELL,
       FILE,
       SALT,
       ANSIBLE,
@@ -33,6 +37,8 @@ module Packer
       end
       {
         SHELL             => Packer::Provisioner::Shell,
+        WINDOWS_SHELL     => Packer::Provisioner::WindowsShell,
+        POWERSHELL        => Packer::Provisioner::Powershell,
         FILE              => Packer::Provisioner::File,
         SALT              => Packer::Provisioner::Salt,
         ANSIBLE           => Packer::Provisioner::Ansible,

--- a/lib/packer/provisioners/all.rb
+++ b/lib/packer/provisioners/all.rb
@@ -1,6 +1,8 @@
 # Encoding: utf-8
 require_relative 'file'
 require_relative 'shell'
+require_relative 'windows_shell'
+require_relative 'powershell'
 require_relative 'salt'
 require_relative 'ansible'
 require_relative 'chef/client'

--- a/lib/packer/provisioners/powershell.rb
+++ b/lib/packer/provisioners/powershell.rb
@@ -1,0 +1,63 @@
+# Encoding: utf-8
+require 'packer/provisioner'
+require 'packer/dataobject'
+
+module Packer
+  class Provisioner < Packer::DataObject
+    class Powershell < Provisioner
+      def initialize
+        super
+        self.data['type'] = POWERSHELL
+        self.add_required(['inline', 'script', 'scripts'])
+        self.add_key_dependencies({
+            'elevated_user' => ['elevated_password'],
+            'elevated_password' => ['elevated_user']
+        })
+      end
+
+      def inline(commands)
+        self.__add_array_of_strings('inline', commands, %w[script scripts])
+      end
+
+      def script(filename)
+        self.__add_string('script', filename, %w[inline scripts])
+      end
+
+      def scripts(filenames)
+        self.__add_array_of_strings('scripts', filenames, %w[inline script])
+      end
+
+      def binary(bool)
+        self.__add_boolean('binary', bool, [])
+      end
+
+      def environment_vars(envpairs)
+        self.__add_array_of_strings('environment_vars', envpairs)
+      end
+
+      def execute_command(command)
+        self.__add_string('execute_command', command)
+      end
+
+      def remote_path(command)
+        self.__add_string('remote_path', command)
+      end
+
+      def start_retry_timeout(time)
+        self.__add_string('start_retry_timeout', string)
+      end
+
+      def valid_exit_codes(codes)
+        self.__add_array_of_ints('valid_exit_codes', codes)
+      end
+
+      def elevated_user(user)
+        self.__add_string('elevated_user', user)
+      end
+
+      def elevated_password(password)
+        self.__add_string('elevated_password', password)
+      end
+    end
+  end
+end

--- a/lib/packer/provisioners/windows_shell.rb
+++ b/lib/packer/provisioners/windows_shell.rb
@@ -1,0 +1,47 @@
+# Encoding: utf-8
+require 'packer/provisioner'
+require 'packer/dataobject'
+
+module Packer
+  class Provisioner < Packer::DataObject
+    class WindowsShell < Provisioner
+      def initialize
+        super
+        self.data['type'] = WINDOWS_SHELL
+        self.add_required(['inline', 'script', 'scripts'])
+      end
+
+      def inline(commands)
+        self.__add_array_of_strings('inline', commands, %w[script scripts])
+      end
+
+      def script(filename)
+        self.__add_string('script', filename, %w[inline scripts])
+      end
+
+      def scripts(filenames)
+        self.__add_array_of_strings('scripts', filenames, %w[inline script])
+      end
+
+      def binary(bool)
+        self.__add_boolean('binary', bool, [])
+      end
+
+      def environment_vars(envpairs)
+        self.__add_array_of_strings('environment_vars', envpairs)
+      end
+
+      def execute_command(command)
+        self.__add_string('execute_command', command)
+      end
+
+      def remote_path(command)
+        self.__add_string('remote_path', command)
+      end
+
+      def start_retry_timeout(time)
+        self.__add_string('start_retry_timeout', string)
+      end
+    end
+  end
+end

--- a/lib/packer/provisioners/windows_shell.rb
+++ b/lib/packer/provisioners/windows_shell.rb
@@ -40,7 +40,7 @@ module Packer
       end
 
       def start_retry_timeout(time)
-        self.__add_string('start_retry_timeout', string)
+        self.__add_string('start_retry_timeout', time)
       end
     end
   end

--- a/spec/packer/provisioners/powershell_spec.rb
+++ b/spec/packer/provisioners/powershell_spec.rb
@@ -1,0 +1,124 @@
+# Encoding: utf-8
+require 'spec_helper'
+
+RSpec.describe Packer::Provisioner::Powershell do
+  let(:provisioner) do
+    Packer::Provisioner.get_provisioner('powershell')
+  end
+
+  let(:some_string) do
+    'some string'
+  end
+
+  let(:some_array_of_strings) do
+    %w[command1 command2]
+  end
+
+  let(:some_array_of_ints) do
+    [1, 2, 3]
+  end
+
+  describe '#initialize' do
+    it 'has a type of powershell' do
+      expect(provisioner.data['type']).to eq('powershell')
+    end
+  end
+
+  describe '#inline' do
+    it 'accepts an array of commands' do
+      provisioner.inline(some_array_of_strings)
+      expect(provisioner.data['inline']).to eq(some_array_of_strings)
+      provisioner.data.delete('inline')
+    end
+
+    it 'converts all commands to strings' do
+      provisioner.inline(some_array_of_ints)
+      expect(provisioner.data['inline']).to eq(some_array_of_ints.map(&:to_s))
+      provisioner.data.delete('inline')
+    end
+
+    it 'raises an error if the commands argument cannot be made an Array' do
+      expect { provisioner.inline(some_string) }.to raise_error
+    end
+
+    it 'raises an error if #script or #scripts method was already called' do
+      provisioner.data['script'] = 1
+      expect { provisioner.inline(some_array_of_strings) }.to raise_error
+      provisioner.data.delete('script')
+      provisioner.data['scripts'] = 1
+      expect { provisioner.inline(some_array_of_strings) }.to raise_error
+      provisioner.data.delete('scripts')
+    end
+  end
+
+  describe '#script' do
+    it 'accepts a string' do
+      provisioner.script(some_string)
+      expect(provisioner.data['script']).to eq(some_string)
+      provisioner.data.delete('script')
+    end
+
+    it 'converts any argument passed to a string' do
+      provisioner.script(some_array_of_ints)
+      expect(provisioner.data['script']).to eq(some_array_of_ints.to_s)
+      provisioner.data.delete('script')
+    end
+
+    it 'raises an error if #inline or #scripts method was already called' do
+      provisioner.data['inline'] = 1
+      expect { provisioner.script(some_string) }.to raise_error
+      provisioner.data.delete('inline')
+      provisioner.data['scripts'] = 1
+      expect { provisioner.script(some_string) }.to raise_error
+      provisioner.data.delete('scripts')
+    end
+  end
+
+  describe '#scripts' do
+    it 'accepts an array of commands' do
+      provisioner.scripts(some_array_of_strings)
+      expect(provisioner.data['scripts']).to eq(some_array_of_strings)
+      provisioner.data.delete('scripts')
+    end
+
+    it 'converts all commands to strings' do
+      provisioner.scripts(some_array_of_ints)
+      expect(provisioner.data['scripts']).to eq(some_array_of_ints.map(&:to_s))
+      provisioner.data.delete('scripts')
+    end
+
+    it 'raises an error if the commands argument cannot be made an Array' do
+      expect { provisioner.scripts(some_string) }.to raise_error
+    end
+
+    it 'raises an error if #inline or #script method was already called' do
+      provisioner.data['script'] = 1
+      expect { provisioner.scripts(some_array_of_strings) }.to raise_error
+      provisioner.data.delete('scripts')
+      provisioner.data['inline'] = 1
+      expect { provisioner.scripts(some_array_of_strings) }.to raise_error
+      provisioner.data.delete('scripts')
+    end
+  end
+
+  describe '#valid_exit_codes' do
+    it 'accepts an array of exit codes' do
+      provisioner.valid_exit_codes(some_array_of_ints)
+      expect(provisioner.data['valid_exit_codes']).to eq(some_array_of_ints)
+      provisioner.data.delete('valid_exit_codes')
+    end
+  end
+
+  describe '#validate' do
+    it 'raises an error if elevated_user is defined and elevated_password is not' do
+      provisioner.inline [some_string]
+      provisioner.elevated_user some_string
+      expect { provisioner.validate }.to raise_error Packer::DataObject::DataValidationError
+    end
+
+    it 'completes with no elevated_user or elevated_password' do
+      provisioner.inline [some_string]
+      expect(provisioner.validate).to be true
+    end
+  end
+end

--- a/spec/packer/provisioners/windows_shell_spec.rb
+++ b/spec/packer/provisioners/windows_shell_spec.rb
@@ -1,0 +1,103 @@
+# Encoding: utf-8
+require 'spec_helper'
+
+RSpec.describe Packer::Provisioner::WindowsShell do
+  let(:provisioner) do
+    Packer::Provisioner.get_provisioner('windows-shell')
+  end
+
+  let(:some_string) do
+    'some string'
+  end
+
+  let(:some_array_of_strings) do
+    %w[command1 command2]
+  end
+
+  let(:some_array_of_ints) do
+    [1, 2, 3]
+  end
+
+  describe '#initialize' do
+    it 'has a type of windows-shell' do
+      expect(provisioner.data['type']).to eq('windows-shell')
+    end
+  end
+
+  describe '#inline' do
+    it 'accepts an array of commands' do
+      provisioner.inline(some_array_of_strings)
+      expect(provisioner.data['inline']).to eq(some_array_of_strings)
+      provisioner.data.delete('inline')
+    end
+
+    it 'converts all commands to strings' do
+      provisioner.inline(some_array_of_ints)
+      expect(provisioner.data['inline']).to eq(some_array_of_ints.map(&:to_s))
+      provisioner.data.delete('inline')
+    end
+
+    it 'raises an error if the commands argument cannot be made an Array' do
+      expect { provisioner.inline(some_string) }.to raise_error
+    end
+
+    it 'raises an error if #script or #scripts method was already called' do
+      provisioner.data['script'] = 1
+      expect { provisioner.inline(some_array_of_strings) }.to raise_error
+      provisioner.data.delete('script')
+      provisioner.data['scripts'] = 1
+      expect { provisioner.inline(some_array_of_strings) }.to raise_error
+      provisioner.data.delete('scripts')
+    end
+  end
+
+  describe '#script' do
+    it 'accepts a string' do
+      provisioner.script(some_string)
+      expect(provisioner.data['script']).to eq(some_string)
+      provisioner.data.delete('script')
+    end
+
+    it 'converts any argument passed to a string' do
+      provisioner.script(some_array_of_ints)
+      expect(provisioner.data['script']).to eq(some_array_of_ints.to_s)
+      provisioner.data.delete('script')
+    end
+
+    it 'raises an error if #inline or #scripts method was already called' do
+      provisioner.data['inline'] = 1
+      expect { provisioner.script(some_string) }.to raise_error
+      provisioner.data.delete('inline')
+      provisioner.data['scripts'] = 1
+      expect { provisioner.script(some_string) }.to raise_error
+      provisioner.data.delete('scripts')
+    end
+  end
+
+  describe '#scripts' do
+    it 'accepts an array of commands' do
+      provisioner.scripts(some_array_of_strings)
+      expect(provisioner.data['scripts']).to eq(some_array_of_strings)
+      provisioner.data.delete('scripts')
+    end
+
+    it 'converts all commands to strings' do
+      provisioner.scripts(some_array_of_ints)
+      expect(provisioner.data['scripts']).to eq(some_array_of_ints.map(&:to_s))
+      provisioner.data.delete('scripts')
+    end
+
+    it 'raises an error if the commands argument cannot be made an Array' do
+      expect { provisioner.scripts(some_string) }.to raise_error
+    end
+
+    it 'raises an error if #inline or #script method was already called' do
+      provisioner.data['script'] = 1
+      expect { provisioner.scripts(some_array_of_strings) }.to raise_error
+      provisioner.data.delete('scripts')
+      provisioner.data['inline'] = 1
+      expect { provisioner.scripts(some_array_of_strings) }.to raise_error
+      provisioner.data.delete('scripts')
+    end
+  end
+end


### PR DESCRIPTION
Hey Ian,

I added some code at the request of my coworkers for these windows provisioners when I saw that the elevated_user and elevated_password keys for the powershell provisioner require eachother's presence. I started writing some code to enforce this and called them "dependencies." I thought this might be useful also for people to add more "dependencies" to get stricter validation in their code (I might want to use it).

Just wanted to get your thoughts before I continue further - it still needs more tests and a tweak here or there. Alternatively I could scrap that idea and just add the provisioners.

The shells all look pretty similar, but there was no logical connection between them in the packer documentation so I didn't give them a base class/module to share logic from.

Thanks!
Greg