### PR TITLE
Allow unchained postprocessors and Docker builder commit/changes params

### DIFF
--- a/lib/packer-config.rb
+++ b/lib/packer-config.rb
@@ -39,7 +39,7 @@ module Packer
     end
 
     def chained_postprocessors?
-      !!self.chained_postprocessors
+      self.chained_postprocessors ? true : false
     end
 
     def validate(verbose: false)
@@ -85,7 +85,7 @@ module Packer
         self.postprocessors.each do |thing|
           data_copy['post-processors'].push(thing.deep_copy)
         end
-        if !self.chained_postprocessors?
+        unless self.chained_postprocessors?
           data_copy['post-processors'] = [data_copy['post-processors']]
         end
       end

--- a/lib/packer-config.rb
+++ b/lib/packer-config.rb
@@ -17,6 +17,7 @@ module Packer
     attr_accessor :provisioners
     attr_accessor :packer
     attr_accessor :packer_options
+    attr_accessor :chained_postprocessors
     attr_reader   :macro
     attr_reader   :envvar
     attr_reader   :output_file
@@ -34,6 +35,11 @@ module Packer
       self.packer_options = []
       self.macro = Macro.new
       self.envvar = EnvVar.new
+      self.chained_postprocessors = true
+    end
+
+    def chained_postprocessors?
+      !!self.chained_postprocessors
     end
 
     def validate(verbose: false)
@@ -78,6 +84,9 @@ module Packer
         data_copy['post-processors'] = []
         self.postprocessors.each do |thing|
           data_copy['post-processors'].push(thing.deep_copy)
+        end
+        if !self.chained_postprocessors?
+          data_copy['post-processors'] = [data_copy['post-processors']]
         end
       end
       case format

--- a/lib/packer/builders/docker.rb
+++ b/lib/packer/builders/docker.rb
@@ -26,7 +26,7 @@ module Packer
       def pull(bool)
         self.__add_boolean('pull', bool)
       end
-      
+
       def changes(changes)
         self.__add_array_of_strings('changes', changes)
       end

--- a/lib/packer/builders/docker.rb
+++ b/lib/packer/builders/docker.rb
@@ -26,6 +26,10 @@ module Packer
       def pull(bool)
         self.__add_boolean('pull', bool)
       end
+      
+      def changes(changes)
+        self.__add_array_of_strings('changes', changes)
+      end
 
       def run_command(commands)
         self.__add_array_of_strings('run_command', commands)

--- a/lib/packer/builders/docker.rb
+++ b/lib/packer/builders/docker.rb
@@ -8,14 +8,15 @@ module Packer
       def initialize
         super
         self.data['type'] = DOCKER
-        self.add_required(
-          'export_path',
-          'image'
-        )
+        self.add_required('image')
       end
 
       def export_path(path)
-        self.__add_string('export_path', path)
+        self.__add_string('export_path', path, ['commit'])
+      end
+
+      def commit(bool)
+        self.__add_boolean('commit', bool, ['export_path'])
       end
 
       def image(name)


### PR DESCRIPTION
Hi! This pull request addresses a couple of pain points I encountered when using this gem for Docker image building workflows:

- Docker builder: Expose the 'commit' and 'changes' parameters. Also, I made the 'commit' parameter mutually exclusive with the 'export_path' one.

- Unchained postprocessors: By default, Packer chains the results of all postprocessors, so that the output of the last one is the input of the next one. For Docker typically you want to tag an image, and then push it, but the output of the docker-tag postprocessor is just a checksum, so it cannot be fed into docker-push. Instead, you need to make all postprocessors run against the builder result, by configuring the postprocessors as a nested list, as in the Packer Docker example(note the nested array):
https://www.packer.io/docs/builders/docker.html#amazon-ec2-container-registry
So I added a Packer::Config boolean switch to nest the array of postprocessors