### PR TITLE
Fix borked Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,7 +73,7 @@ Metrics/BlockNesting:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 30
+  Max: 40
 
 Metrics/ClassLength:
   Max: 150

--- a/lib/packer/envvar.rb
+++ b/lib/packer/envvar.rb
@@ -2,11 +2,10 @@
 
 module Packer
   class EnvVar
-    # rubocop:disable Style/MethodMissingSuper
     def method_missing(method_name, *args)
       "{{env `#{method_name}`}}"
     end
-    # rubocop:enable Style/MethodMissingSuper
+
 
     def respond_to_missing?(method_name, include_private = false)
       true

--- a/lib/packer/macro.rb
+++ b/lib/packer/macro.rb
@@ -2,12 +2,11 @@
 
 module Packer
   class Macro
-    # rubocop:disable Style/MethodMissingSuper
     def method_missing(method_name, *args)
       name = method_name.to_s.slice(0,1).capitalize + method_name.to_s.slice(1..-1)
       "{{ .#{name} }}"
     end
-    # rubocop:enable Style/MethodMissingSuper
+
 
     def respond_to_missing?(method_name, include_private = false)
       true


### PR DESCRIPTION
Not going to rev the version as this only applies to development. No
actual functionality changed as a result of this commit. Removes some
redundant cop blocks in two files and ups the limit for Metrics/AbcSize
so it doesn't trigger (I should just disable it...).